### PR TITLE
Update Contribute.md [Cloning Repository command]

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -106,7 +106,10 @@ Click on fork to create a copy of project to your account. This creates a separa
 
 You have forked the project you want to contribute to your github account. To get this project on your development machine we use clone command of git.
 
-`$ git clone https://github.com/girlscript/winter-of-contributing.git` <br/>
+`$ git clone https://github.com/[Add_Here_Your_UserName]/winter-of-contributing.git` <br/>
+
+Example: If your git-hub User-name is Meet19aug then type command `$ git clone https://github.com/Meet19aug/winter-of-contributing.git`
+
 Now you have the project on your local machine.
 
 <br />


### PR DESCRIPTION
<hr>

## Description 📜

Path: winter-of-contributing/.github/CONTRIBUTING.md in main

In Contributing guideline rather than giving an absolute command example, I tried to make contributors more clear to clone their own repository in their local environment instead of the [girlscript/winter-of-contributing repository], so they can push the command directly from the command line.

<hr>

## Type of change 📝

<!----Please delete the hashtag from the correct option----->

- [X] Documentation (Content Creation in the form of codes or tutorials)

<hr>

## Domain of Contribution 📊

<!----Please delete the hashtag from your domain----->

- [x] Contributing Guidline 

<hr>

## Checklist ✅

<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [Contributing Guidelines](https://github.com/girlscript/winter-of-contributing/blob/main/.github/CONTRIBUTING.md) & [Code of conduct](https://github.com/girlscript/winter-of-contributing/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] My changes generates no new warnings.
- [x] I'm GWOC'21 contributor

<hr>

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->


<hr>
