### PR TITLE
Android-java :4.3 (batch-5) StartActivityForResult-Example 

### DIFF
--- a/Android_Development_With_Java/3  Activity and Intents/4.3 Start Activity For Result.md
+++ b/Android_Development_With_Java/3  Activity and Intents/4.3 Start Activity For Result.md
@@ -1,0 +1,44 @@
+# Start an Activity For Result
+This documentation contains how to get a result from an activity. Starting another activity and getting the result does not need to be a one-way operation. This can also be done by starting another activity and receiving the result from that activity in your current activity. Here I am showing an example where one can click on the button to upload an image from the internal storage of the phone and that image will be displayed in the imageview.
+
+
+**First make a new project in android.**
+
+![Picture_1](https://user-images.githubusercontent.com/70054805/136223679-b5d0bfbd-b865-425d-b7b4-2b2dbc25d798.png)
+
+
+**Give the name whatever you want and select the language java.**
+
+![Picture_2](https://user-images.githubusercontent.com/70054805/136224698-19c8ecbb-e184-4882-9ef2-930b0a7f7e80.png)
+
+
+**Now in layout set an ImageView and a button**
+
+![Picture_3](https://user-images.githubusercontent.com/70054805/136221670-6161500d-453e-4714-adbc-2db54f2de839.png)
+
+
+ In java class define the ImageView and button variables then follow the steps listed below.
+
+ Registering a callback for an Activity Result
+
+- `registerForActivityResult()` API is for registering the result callback while the image is selected. `registerForActivityResult()` takes an `ActivityResultContract` and an `ActivityResultCallback` where imageURI is set on the image, and returns an `ActivityResultLauncher` which will be used to launch the result .
+
+
+ - An `ActivityResultContract` defines the input type needed to produce a result along with the output type of the result. Here the contract used is default(default contracts) to take the picture, various contracts are there for different intent actions such as to take video to request multiple permissions and so on.
+
+![Picture_4](https://user-images.githubusercontent.com/70054805/136221760-0927e46c-f53d-492f-83db-52c501b7beeb.png)
+
+## Launching an activity for result
+
+- While `registerForActivityResult()` registers the callback, but does not launch the activity and rejects the request for a result. When onActivityResult() from the ActivityResultCallback is executed, calling launch() starts the process of producing the result
+
+
+![Picture_5](https://user-images.githubusercontent.com/70054805/136222022-277564d1-e0c7-492e-80ff-448e870fabe4.png)
+
+
+## After uploading the image, in the activity result URI is received and the corresponding image is launched and shows up.
+
+
+![Picture_6](https://user-images.githubusercontent.com/70054805/136222091-be2eddb0-7dfb-4c7c-b032-ee4eb252cc06.png)
+
+For more information please visit (https://developer.android.com/training/basics/intents/result)


### PR DESCRIPTION
<hr>

## Description 📜
How to receive a result inside activity using method startActivityForResult(), getActivityResult().
Fixes #277 

<hr>

## Type of change 📝

<!----Please delete the hashtag from the correct option----->

- [ ] Au#dio (Should be in mp3 format Includes speech clarity, Concise ,Low distortion)
- [ ] Vi#deo (Animations, screen-recordings, presentations and regular explanatory films are all possibilties etc)
- [x] Doc#umentation (Content Creation in the form of codes or tutorials)
- [ ] Other (If you choose other, Please mention changes below) 

<hr>

## Domain of Contribution 📊

<!----Please delete the hashtag from your domain----->

- [ ] Android Dev #(Flutter)
- [x] Android Dev #(Java)
- [ ] Android Dev #(Kotlin)
- [ ] Backend Dev #(Java)
- [ ] Backend Dev #(.NET)
- [ ] Backend Dev #(PHP)
- [ ] Backend Dev #(Python)
- [ ] C/#CPP
- [ ] Competitive #Programming
- [ ] Cyber #Security
- [ ] DS#A
- [ ] Data#base
- [ ] Datascience with #Python
- [ ] Datascience with #R
- [ ] Frontend Dev #HTML/CSS/JS
- [ ] Frontend Dev #React/Angular/Vue
- [ ] Go#lang
- [ ] Interview #Prep
- [ ] Java_#Domain
- [ ] JavaScript_#Domain
- [ ] ME#RN
- [ ] Machine #Learning
- [ ] Open #Source
- [ ] Python_#Domain
- [ ] Ru#st
- [ ] Statis#tics
- [ ] UI/#UX

<hr>

## Checklist ✅

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [Contributing Guidelines](https://github.com/girlscript/winter-of-contributing/blob/main/.github/CONTRIBUTING.md) & [Code of conduct](https://github.com/girlscript/winter-of-contributing/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I'm GWOC'21 contributor


