### PR TITLE
DSA 3.2.12 Greedy algorithms :Reverse delete algorithm for MST-audio

### DIFF
--- a/DSA/3.2 Greedy Algorithms/12. Reverse delete algorithm for MST-audio.md
+++ b/DSA/3.2 Greedy Algorithms/12. Reverse delete algorithm for MST-audio.md
@@ -1,0 +1,71 @@
+# Reverse Delete Algorithm for MST
+
+[Reverse Delete Algorithm audio](https://drive.google.com/file/d/1WBjM_L7max3JALnd6f5V7-edqLMKlH3u/view?usp=sharing)
+
+### Summary of audio
+
+A spanning tree is a subset of a graph that connects all the vertices together. There can be multiple spanning trees for a single graph. However, the spanning tree that has the minimum cumulative cost of it’s edges is called the minimum spanning tree. 
+
+The reverse delete algorithm is a method for obtaining a minimum spanning tree from a connected and weighted graph, using a greedy approach. 
+
+---
+### Algorithm
+1. Sort all the edges in decreasing order of their weights.
+2. Initialize the MST as the original graph.
+3. Select the edge with the maximum weight
+4. If removing the edge disconnects the graph, the keep the edge as it is
+    Else remove the edge
+5. Move on to the next edge with the maximum weight
+---
+### Time and Space Complexity
+The time complexity for the reverse deletion algorithm can be derived as O(E log V(log log V)3 ), where E is the number of edges and V is the number of vertices in the graph. Whereas the space complexity remains O(V+E).
+
+---
+
+### Example
+
+![alt text](https://i.ibb.co/zQ09djJ/1.jpg)
+
+![alt text](https://i.ibb.co/yV00vPm/2.jpg)
+
+---
+
+### Implementation
+```
+void Graph::reverseDeleteMST()
+{
+    // Sort edges in increasing order on basis of cost
+    sort(edges.begin(), edges.end());
+  
+    int mst_wt = 0;  // Initialize weight of MST
+  
+    cout << "Edges in MST\n";
+  
+    // Iterate through all sorted edges in
+    // decreasing order of weights
+    for (int i=edges.size()-1; i>=0; i--)
+    {
+        int u = edges[i].second.first;
+        int v = edges[i].second.second;
+  
+        // Remove edge from undirected graph
+        adj[u].remove(v);
+        adj[v].remove(u);
+  
+        // Adding the edge back if removing it
+        // causes disconnection. In this case this 
+        // edge becomes part of MST.
+        if (isConnected() == false)
+        {
+            adj[u].push_back(v);
+            adj[v].push_back(u);
+  
+            // This edge is part of MST
+            cout << "(" << u << ", " << v << ") \n";
+            mst_wt += edges[i].first;
+        }
+    }
+  
+    cout << "Total weight of MST is " << mst_wt;
+}
+```


### PR DESCRIPTION
<hr>

## Description 📜
I've included an audio clip on the reverse delete algorithm for a minimum spanning tree, along with an example and implementation for the same. I've also added a documented summary of the audio clip. 
Fixes #5770

<hr>

## Type of change 📝

<!----Please delete the hashtag from the correct option----->

- [x] Audio (Should be in mp3 format Includes speech clarity, Concise ,Low distortion)
- [ ] Vi#deo (Animations, screen-recordings, presentations and regular explanatory films are all possibilties etc)
- [ ] Doc#umentation (Content Creation in the form of codes or tutorials)
- [ ] Other (If you choose other, Please mention changes below) 

<hr>

## Domain of Contribution 📊

<!----Please delete the hashtag from your domain----->

- [ ] Android Dev #(Flutter)
- [ ] Android Dev #(Java)
- [ ] Android Dev #(Kotlin)
- [ ] Backend Dev #(Java)
- [ ] Backend Dev #(.NET)
- [ ] Backend Dev #(PHP)
- [ ] Backend Dev #(Python)
- [ ] C/#CPP
- [ ] Competitive #Programming
- [ ] Cyber #Security
- [x] DSA
- [ ] Data#base
- [ ] Datascience with #Python
- [ ] Datascience with #R
- [ ] Frontend Dev #HTML/CSS/JS
- [ ] Frontend Dev #React/Angular/Vue
- [ ] Go#lang
- [ ] Interview #Prep
- [ ] Java_#Domain
- [ ] JavaScript_#Domain
- [ ] ME#RN
- [ ] Machine #Learning
- [ ] Open #Source
- [ ] Python_#Domain
- [ ] Ru#st
- [ ] Statis#tics
- [ ] UI/#UX

<hr>

## Checklist ✅

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [Contributing Guidelines](https://github.com/girlscript/winter-of-contributing/blob/main/.github/CONTRIBUTING.md) & [Code of conduct](https://github.com/girlscript/winter-of-contributing/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I'm GWOC'21 contributor

<hr>

<!----Please delete options that are not relevant.----->

## Screenshots / Gif (Optional) 📸

<hr>
